### PR TITLE
OTA: Updates OTA URLs for 8 series

### DIFF
--- a/OTA/GMS/akita.json
+++ b/OTA/GMS/akita.json
@@ -6,7 +6,7 @@
             "id": "23e64b4e15b1e28804761d19653ab503",
             "romtype": "OFFICIAL",
             "size": 1992669301,
-            "url": "https://github.com/AxionAOSP/AxionOS_Pixels/releases/download/2.3/axion-2.3-TELOS-20260111-OFFICIAL-GMS-akita.zip",
+            "url": "https://sourceforge.net/projects/axionaosp-elitedarkkaiser/files/akita/2.x/GMS/axion-2.3-TELOS-20260111-OFFICIAL-GMS-akita.zip/download",
             "version": "2.3"
         }
     ]

--- a/OTA/GMS/husky.json
+++ b/OTA/GMS/husky.json
@@ -6,7 +6,7 @@
             "id": "98cc0cb91cd624a74bcf4369a5a43bbf",
             "romtype": "OFFICIAL",
             "size": 2014969969,
-            "url": "https://github.com/AxionAOSP/AxionOS_Pixels/releases/download/2.3/axion-2.3-TELOS-20260111-OFFICIAL-GMS-husky.zip",
+            "url": "https://sourceforge.net/projects/axionaosp-elitedarkkaiser/files/husky/2.x/GMS/axion-2.3-TELOS-20260111-OFFICIAL-GMS-husky.zip/download",
             "version": "2.3"
         }
     ]

--- a/OTA/GMS/shiba.json
+++ b/OTA/GMS/shiba.json
@@ -6,7 +6,7 @@
             "id": "c9656ab9846c5f7fab855115b5f37d6b",
             "romtype": "OFFICIAL",
             "size": 2001157057,
-            "url": "https://github.com/AxionAOSP/AxionOS_Pixels/releases/download/2.3/axion-2.3-TELOS-20260111-OFFICIAL-GMS-shiba.zip",
+            "url": "https://sourceforge.net/projects/axionaosp-elitedarkkaiser/files/shiba/2.x/GMS/axion-2.3-TELOS-20260111-OFFICIAL-GMS-shiba.zip/download",
             "version": "2.3"
         }
     ]

--- a/OTA/VANILLA/akita.json
+++ b/OTA/VANILLA/akita.json
@@ -6,7 +6,7 @@
             "id": "bc7d99a6de7cb7ad0ea98890212fb1bc",
             "romtype": "OFFICIAL",
             "size": 1603566837,
-            "url": "https://github.com/AxionAOSP/AxionOS_Pixels/releases/download/2.3/axion-2.3-TELOS-20260111-OFFICIAL-VANILLA-akita.zip",
+            "url": "https://sourceforge.net/projects/axionaosp-elitedarkkaiser/files/akita/2.x/Vanilla/axion-2.3-TELOS-20260111-OFFICIAL-VANILLA-akita.zip/download",
             "version": "2.3"
         }
     ]

--- a/OTA/VANILLA/husky.json
+++ b/OTA/VANILLA/husky.json
@@ -6,7 +6,7 @@
             "id": "3b3fac6e65ff971fa37df39565c9be19",
             "romtype": "OFFICIAL",
             "size": 1625612563,
-            "url": "https://github.com/AxionAOSP/AxionOS_Pixels/releases/download/2.3/axion-2.3-TELOS-20260111-OFFICIAL-VANILLA-husky.zip",
+            "url": "https://sourceforge.net/projects/axionaosp-elitedarkkaiser/files/husky/2.x/Vanilla/axion-2.3-TELOS-20260111-OFFICIAL-VANILLA-husky.zip/download",
             "version": "2.3"
         }
     ]

--- a/OTA/VANILLA/shiba.json
+++ b/OTA/VANILLA/shiba.json
@@ -6,7 +6,7 @@
             "id": "11b7d60d03ca4db41fe31fd0469c3354",
             "romtype": "OFFICIAL",
             "size": 1611261373,
-            "url": "https://github.com/AxionAOSP/AxionOS_Pixels/releases/download/2.3/axion-2.3-TELOS-20260111-OFFICIAL-VANILLA-shiba.zip",
+            "url": "https://sourceforge.net/projects/axionaosp-elitedarkkaiser/files/shiba/2.x/Vanilla/axion-2.3-TELOS-20260111-OFFICIAL-VANILLA-shiba.zip/download",
             "version": "2.3"
         }
     ]


### PR DESCRIPTION
Updates the OTA update URLs from GitHub to SourceForge for the akita, husky, and shiba devices. This ensures that devices correctly receive updates from the new hosting location.

Change-Id: I1278c7943de4f75ad10be8e13faa1faf1b05284a