### PR TITLE
Wiki: Create installation guide for Itel RS4 (S666LN)

### DIFF
--- a/Wiki/S666LN.md
+++ b/Wiki/S666LN.md
@@ -1,0 +1,62 @@
+# Installation Guide — Itel RS4 (S666LN)
+
+> [!WARNING]
+> - Your warranty is void.
+> - All official release builds are tested and safe to use.
+> - If you decide to experiment, mess something up, corrupt your storage, turn your phone into a fancy paperweight, or brick it beyond recovery — **don’t blame us**.
+> - You are doing this at **your own risk** and take full responsibility for anything that may happen.
+
+> [!NOTE]
+> - The device must have an **unlocked bootloader** and a **recommended custom recovery**.
+> - Make a **full data backup** before flashing.
+> - Ensure your device has at least **30% battery**.
+> - Flash **only** files meant for **Itel RS4**.
+> - First boot may take 5–10 minutes. Do **not** interrupt or force reboot unless it exceeds 10 minutes.
+> - Please make an IMEI backup.
+
+---
+
+## Clean Installation (same for AOSP Recovery)
+
+1. Boot into your **preferred recovery**.
+2. Select **Wipe → Format Data** and type `yes`.
+3. Flash the **ROM**. *For flashing can use adb sideload or using micro sd card.*
+4. If you're using the **vanilla build** reboot recovery **NOW!**
+5. flash **GApps** now. *If you are using the **GMS build**, skip this step.*
+6. Reboot to **System**. 
+
+---
+
+## Update (Dirty Flash)
+
+> [!NOTE]
+> Dirty flashing **will not work** for major Android version upgrades  
+> (example: **1.x → 2.x**).
+
+### Method 1: OTA Update
+
+1. Go to **Settings → System → System updates**.
+2. Download the latest available build.
+3. Tap **Reboot** once the download finishes.
+4. The device will reboot into recovery and install the update.
+6. Reboot to **System**.
+
+---
+
+### Method 2: Recovery Flash
+
+1. Reboot to **Recovery**.
+2. Select **Install → Choose ROM → Swipe to flash**.
+3. Reboot to **System**.
+
+---
+
+> [!IMPORTANT]
+> For **vanilla builds**, **GApps must be reflashed after every update**,  
+> including **OTA** and **recovery-based dirty flashes**.
+
+---
+
+## Support / Bug Reports
+
+📢 **[Telegram Group](https://t.me/itel_rs4)** 


### PR DESCRIPTION
* Added an installation guide for the Itel RS4 (S666LN) including clean installation and update methods.