### PR TITLE
Adds Google Pixel 10 series device support

### DIFF
--- a/OTA/axion.devices
+++ b/OTA/axion.devices
@@ -10,7 +10,10 @@ husky
 tokay
 felix
 caiman  
-komodo  
+komodo 
+frankel
+blazer
+mustang 
 duchamp
 sweet
 begonia

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@
 | **Google Pixel 9 Pro**     | `caiman`     |
 | **Google Pixel 9 Pro XL**  | `komodo`     |
 | **Google Pixel Fold**      | `felix`     |
+| **Google Pixel 10**        | `frankel`    |
+| **Google Pixel 10 Pro**    | `blazer`     |
+| **Google Pixel 10 Pro XL** | `mustang`    |
 | **Itel RS4**               | `S666LN`     |
 | **Motorola G34/45 5G**     | `fogos`    |
 | **Motorola G54**           | `cancunf`    |
@@ -53,6 +56,7 @@
 
 ## 👤 Maintainers
 - **[rmp22](https://github.com/rmp22)** (Pixel 6-8 series, Pixel Fold - Open for Co-Maintainership/Take over)
+- **[EliteDarkKaiser](https://github.com/austineyoung2000)** (Pixel 10 series - Open for Co-Maintainership)
 - **[Ayan](https://github.com/not-ayan)** (Motorola G54)
 - **[Itachi](https://github.com/manidweep)** (Oneplus 8 series)
 - **[beingashwani](https://github.com/beingashwani)** (POCO F5/Nothing CMF Phone 1)

--- a/Wiki/blazer.md
+++ b/Wiki/blazer.md
@@ -1,0 +1,96 @@
+# Install AxionOS on blazer
+
+> [!WARNING]
+> Flashing an older bootloader, radio, or firmware than what is on the device may trip ARB and will permanently brick it. Always flash an AxionOS build whose firmware is the same or newer than your current one.
+
+> [!WARNING]
+> Do not relock the bootloader while AxionOS is installed. It will fail verified boot, wipe your data, and may brick the device.
+
+## Before you start
+
+- Read this page through once before doing anything.
+- Install `adb` and `fastboot` on your computer.
+- Enable USB debugging on the device.
+- Boot the stock OS at least once and confirm calls, SMS and mobile data work.
+- Sign out of any Google accounts to avoid Factory Reset Protection.
+- Back up anything you want to keep. Unlocking the bootloader wipes the device.
+- The device must be on the **Android 16** stock firmware before installing AxionOS. Mismatched firmware can cause boot failures or damage.
+
+## Unlock the bootloader
+
+Only needs to be done once.
+
+1. In *Developer options*, enable **OEM unlocking**.
+2. Reboot to the bootloader:
+   ```
+   adb reboot bootloader
+   ```
+3. Confirm the device shows up:
+   ```
+   fastboot devices
+   ```
+4. Unlock:
+   ```
+   fastboot flashing unlock
+   ```
+   Confirm on the device when prompted.
+5. The device reboots and wipes itself. Re-enable USB debugging when it's back up.
+
+## Flash the AxionOS recovery
+
+1. Download `vendor_boot.img` for **blazer** from the [AxionOS website](https://cdn.axionos.org).
+2. Reboot to the bootloader:
+   ```
+   adb reboot bootloader
+   ```
+3. Flash it:
+   ```
+   fastboot flash vendor_boot vendor_boot.img
+   ```
+4. From the bootloader menu, use the volume keys to highlight **Recovery mode** and press the power button to select.
+
+## Install AxionOS
+
+1. Download `axion-*-blazer.zip` from the [AxionOS website](https://cdn.axionos.org).
+2. In recovery, pick **Factory reset → Format data / factory reset** and confirm.
+3. Back at the main menu, pick **Apply update → Apply from ADB**.
+4. Sideload the ROM:
+   ```
+   adb sideload axion-*-blazer.zip
+   ```
+5. Do **not** reboot yet if you need to install GApps.
+
+## Add-ons (vanilla builds only)
+
+> [!NOTE]
+> GMS builds already ship with Google Apps. Skip this section.
+
+GApps must be installed before the first boot.
+
+1. Pick **Apply update → Apply from ADB** again.
+2. Sideload the GApps zip:
+   ```
+   adb sideload /path/to/gapps.zip
+   ```
+3. If you see *Signature verification failed*, accept it. Add-ons aren't signed with the AxionOS key.
+
+## Reboot
+
+Pick **Reboot system now** from the recovery menu. First boot can take up to 15 minutes.
+
+## Updating
+
+### OTA
+
+*Settings → System → System update*. Download, install, reboot.
+
+### Recovery sideload
+
+Boot into recovery and repeat the sideload step with the new ROM zip. Formatting data is not required for a dirty flash.
+
+> [!IMPORTANT]
+> Vanilla builds need GApps re-sideloaded after every update, including OTAs. GMS builds do not.
+
+## Support
+
+- [Telegram group](https://t.me/+E67IdG0vR0gzZWEx)

--- a/Wiki/frankel.md
+++ b/Wiki/frankel.md
@@ -1,0 +1,96 @@
+# Install AxionOS on frankel
+
+> [!WARNING]
+> Flashing an older bootloader, radio, or firmware than what is on the device may trip ARB and will permanently brick it. Always flash an AxionOS build whose firmware is the same or newer than your current one.
+
+> [!WARNING]
+> Do not relock the bootloader while AxionOS is installed. It will fail verified boot, wipe your data, and may brick the device.
+
+## Before you start
+
+- Read this page through once before doing anything.
+- Install `adb` and `fastboot` on your computer.
+- Enable USB debugging on the device.
+- Boot the stock OS at least once and confirm calls, SMS and mobile data work.
+- Sign out of any Google accounts to avoid Factory Reset Protection.
+- Back up anything you want to keep. Unlocking the bootloader wipes the device.
+- The device must be on the **Android 16** stock firmware before installing AxionOS. Mismatched firmware can cause boot failures or damage.
+
+## Unlock the bootloader
+
+Only needs to be done once.
+
+1. In *Developer options*, enable **OEM unlocking**.
+2. Reboot to the bootloader:
+   ```
+   adb reboot bootloader
+   ```
+3. Confirm the device shows up:
+   ```
+   fastboot devices
+   ```
+4. Unlock:
+   ```
+   fastboot flashing unlock
+   ```
+   Confirm on the device when prompted.
+5. The device reboots and wipes itself. Re-enable USB debugging when it's back up.
+
+## Flash the AxionOS recovery
+
+1. Download `vendor_boot.img` for **frankel** from the [AxionOS website](https://cdn.axionos.org).
+2. Reboot to the bootloader:
+   ```
+   adb reboot bootloader
+   ```
+3. Flash it:
+   ```
+   fastboot flash vendor_boot vendor_boot.img
+   ```
+4. From the bootloader menu, use the volume keys to highlight **Recovery mode** and press the power button to select.
+
+## Install AxionOS
+
+1. Download `axion-*-frankel.zip` from the [AxionOS website](https://cdn.axionos.org).
+2. In recovery, pick **Factory reset → Format data / factory reset** and confirm.
+3. Back at the main menu, pick **Apply update → Apply from ADB**.
+4. Sideload the ROM:
+   ```
+   adb sideload axion-*-frankel.zip
+   ```
+5. Do **not** reboot yet if you need to install GApps.
+
+## Add-ons (vanilla builds only)
+
+> [!NOTE]
+> GMS builds already ship with Google Apps. Skip this section.
+
+GApps must be installed before the first boot.
+
+1. Pick **Apply update → Apply from ADB** again.
+2. Sideload the GApps zip:
+   ```
+   adb sideload /path/to/gapps.zip
+   ```
+3. If you see *Signature verification failed*, accept it. Add-ons aren't signed with the AxionOS key.
+
+## Reboot
+
+Pick **Reboot system now** from the recovery menu. First boot can take up to 15 minutes.
+
+## Updating
+
+### OTA
+
+*Settings → System → System update*. Download, install, reboot.
+
+### Recovery sideload
+
+Boot into recovery and repeat the sideload step with the new ROM zip. Formatting data is not required for a dirty flash.
+
+> [!IMPORTANT]
+> Vanilla builds need GApps re-sideloaded after every update, including OTAs. GMS builds do not.
+
+## Support
+
+- [Telegram group](https://t.me/+E67IdG0vR0gzZWEx)

--- a/Wiki/mustang.md
+++ b/Wiki/mustang.md
@@ -1,0 +1,96 @@
+# Install AxionOS on mustang
+
+> [!WARNING]
+> Flashing an older bootloader, radio, or firmware than what is on the device may trip ARB and will permanently brick it. Always flash an AxionOS build whose firmware is the same or newer than your current one.
+
+> [!WARNING]
+> Do not relock the bootloader while AxionOS is installed. It will fail verified boot, wipe your data, and may brick the device.
+
+## Before you start
+
+- Read this page through once before doing anything.
+- Install `adb` and `fastboot` on your computer.
+- Enable USB debugging on the device.
+- Boot the stock OS at least once and confirm calls, SMS and mobile data work.
+- Sign out of any Google accounts to avoid Factory Reset Protection.
+- Back up anything you want to keep. Unlocking the bootloader wipes the device.
+- The device must be on the **Android 16** stock firmware before installing AxionOS. Mismatched firmware can cause boot failures or damage.
+
+## Unlock the bootloader
+
+Only needs to be done once.
+
+1. In *Developer options*, enable **OEM unlocking**.
+2. Reboot to the bootloader:
+   ```
+   adb reboot bootloader
+   ```
+3. Confirm the device shows up:
+   ```
+   fastboot devices
+   ```
+4. Unlock:
+   ```
+   fastboot flashing unlock
+   ```
+   Confirm on the device when prompted.
+5. The device reboots and wipes itself. Re-enable USB debugging when it's back up.
+
+## Flash the AxionOS recovery
+
+1. Download `vendor_boot.img` for **mustang** from the [AxionOS website](https://cdn.axionos.org).
+2. Reboot to the bootloader:
+   ```
+   adb reboot bootloader
+   ```
+3. Flash it:
+   ```
+   fastboot flash vendor_boot vendor_boot.img
+   ```
+4. From the bootloader menu, use the volume keys to highlight **Recovery mode** and press the power button to select.
+
+## Install AxionOS
+
+1. Download `axion-*-mustang.zip` from the [AxionOS website](https://cdn.axionos.org).
+2. In recovery, pick **Factory reset → Format data / factory reset** and confirm.
+3. Back at the main menu, pick **Apply update → Apply from ADB**.
+4. Sideload the ROM:
+   ```
+   adb sideload axion-*-mustang.zip
+   ```
+5. Do **not** reboot yet if you need to install GApps.
+
+## Add-ons (vanilla builds only)
+
+> [!NOTE]
+> GMS builds already ship with Google Apps. Skip this section.
+
+GApps must be installed before the first boot.
+
+1. Pick **Apply update → Apply from ADB** again.
+2. Sideload the GApps zip:
+   ```
+   adb sideload /path/to/gapps.zip
+   ```
+3. If you see *Signature verification failed*, accept it. Add-ons aren't signed with the AxionOS key.
+
+## Reboot
+
+Pick **Reboot system now** from the recovery menu. First boot can take up to 15 minutes.
+
+## Updating
+
+### OTA
+
+*Settings → System → System update*. Download, install, reboot.
+
+### Recovery sideload
+
+Boot into recovery and repeat the sideload step with the new ROM zip. Formatting data is not required for a dirty flash.
+
+> [!IMPORTANT]
+> Vanilla builds need GApps re-sideloaded after every update, including OTAs. GMS builds do not.
+
+## Support
+
+- [Telegram group](https://t.me/+E67IdG0vR0gzZWEx)

--- a/dinfo.json
+++ b/dinfo.json
@@ -118,6 +118,33 @@
       "status": "Active"
     },
     {
+      "device_name": "Google Pixel 10",
+      "codename": "frankel",
+      "maintainer": "EliteDarkKaiser",
+      "github_username": "austineyoung2000",
+      "support_group": "https://t.me/+E67IdG0vR0gzZWEx",
+      "image_url": "https://fdn2.gsmarena.com/vv/bigpic/google-pixel-10-.jpg",
+      "status": "Active"
+    },
+    {
+      "device_name": "Google Pixel 10 Pro",
+      "codename": "blazer",
+      "maintainer": "EliteDarkKaiser",
+      "github_username": "austineyoung2000",
+      "support_group": "https://t.me/+E67IdG0vR0gzZWEx",
+      "image_url": "https://fdn2.gsmarena.com/vv/bigpic/google-pixel-10-pro-.jpg",
+      "status": "Active"
+    },
+    {
+      "device_name": "Google Pixel 10 Pro XL",
+      "codename": "blazer",
+      "maintainer": "EliteDarkKaiser",
+      "github_username": "austineyoung2000",
+      "support_group": "https://t.me/+E67IdG0vR0gzZWEx",
+      "image_url": "https://fdn2.gsmarena.com/vv/bigpic/google-pixel-10-pro-xl-.jpg",
+      "status": "Active"
+    },
+    {
       "device_name": "Motorola G34/45 5G",
       "codename": "fogos",
       "maintainer": "Byben",


### PR DESCRIPTION
Introduces `frankel` (Pixel 10), `blazer` (Pixel 10 Pro), and `mustang` (Pixel 10 Pro XL) to the supported device list.

Includes dedicated installation guides in the Wiki and updates the main README with device information. Adds metadata for the new devices to `dinfo.json`, assigning EliteDarkKaiser as the maintainer for the Pixel 10 series.