### PR TITLE
Adds AxionOS v2.5 REVERIE initial release for Pixel 10 Series

### DIFF
--- a/OTA/CHANGELOG/blazer.txt
+++ b/OTA/CHANGELOG/blazer.txt
@@ -1,0 +1,5 @@
+AxionOS v2.5 REVERIE
+Build Date : 11/04/2026
+- Synced with latest AxionAOSP sources (11/04/2026)
+- Initial Release
+

--- a/OTA/CHANGELOG/frankel.txt
+++ b/OTA/CHANGELOG/frankel.txt
@@ -1,0 +1,5 @@
+AxionOS v2.5 REVERIE
+Build Date : 11/04/2026
+- Synced with latest AxionAOSP sources (11/04/2026)
+- Initial Release
+

--- a/OTA/CHANGELOG/mustang.txt
+++ b/OTA/CHANGELOG/mustang.txt
@@ -1,0 +1,5 @@
+AxionOS v2.5 REVERIE
+Build Date : 11/04/2026
+- Synced with latest AxionAOSP sources (11/04/2026)
+- Initial Release
+

--- a/OTA/GMS/blazer.json
+++ b/OTA/GMS/blazer.json
@@ -1,0 +1,13 @@
+{
+    "response": [
+        {
+            "datetime": 1775933754,
+            "filename": "axion-2.5-REVERIE-20260411-OFFICIAL-GMS-blazer.zip",
+            "id": "b3f0896d00a8ddf53f4f8e08d9e65375",
+            "romtype": "OFFICIAL",
+            "size": 3201196659,
+            "url": "https://sourceforge.net/projects/axionaosp-for-pixel-10-series/files/blazer/axion-2.5-REVERIE-20260411-OFFICIAL-GMS-blazer.zip/download",
+            "version": "2.5"
+        }
+    ]
+}

--- a/OTA/GMS/frankel.json
+++ b/OTA/GMS/frankel.json
@@ -1,0 +1,13 @@
+{
+    "response": [
+        {
+            "datetime": 1775934542,
+            "filename": "axion-2.5-REVERIE-20260411-OFFICIAL-GMS-frankel.zip",
+            "id": "f9f915152613457e78581ad755b03ab5",
+            "romtype": "OFFICIAL",
+            "size": 3198059830,
+            "url": "https://sourceforge.net/projects/axionaosp-for-pixel-10-series/files/frankel/axion-2.5-REVERIE-20260411-OFFICIAL-GMS-frankel.zip/download",
+            "version": "2.5"
+        }
+    ]
+}

--- a/OTA/GMS/mustang.json
+++ b/OTA/GMS/mustang.json
@@ -1,0 +1,13 @@
+{
+    "response": [
+        {
+            "datetime": 1775931541,
+            "filename": "axion-2.5-REVERIE-20260411-OFFICIAL-GMS-mustang.zip",
+            "id": "44a00bf10c1980e4a6335e85f4ee9560",
+            "romtype": "OFFICIAL",
+            "size": 3205453414,
+            "url": "https://sourceforge.net/projects/axionaosp-for-pixel-10-series/files/mustang/axion-2.5-REVERIE-20260411-OFFICIAL-GMS-mustang.zip/download",
+            "version": "2.5"
+        }
+    ]
+}

--- a/dinfo.json
+++ b/dinfo.json
@@ -137,7 +137,7 @@
     },
     {
       "device_name": "Google Pixel 10 Pro XL",
-      "codename": "blazer",
+      "codename": "mustang",
       "maintainer": "EliteDarkKaiser",
       "github_username": "austineyoung2000",
       "support_group": "https://t.me/+E67IdG0vR0gzZWEx",


### PR DESCRIPTION
Provides initial AxionOS v2.5 REVERIE release details for blazer, frankel, and mustang devices. Includes new changelog entries and GMS OTA JSON manifests for official builds. Corrects the device codename for Google Pixel 10 Pro XL from 'blazer' to 'mustang'.