### PR TITLE
muzel: Updates AxionOS to v2.6 QUASIS release

### DIFF
--- a/OTA/CHANGELOG/blazer.txt
+++ b/OTA/CHANGELOG/blazer.txt
@@ -1,3 +1,10 @@
+AxionOS v2.6 QUASIS
+Build Date : 23/05/2026
+- Synced with latest AxionAOSP sources (23/05/2026)
+- Added Google Face Unlock for better device security ang use of hardware
+- Vendor Firmware stripped so users with may firmware dont brick!!
+- Vanilla Builds are now here!!!
+
 AxionOS v2.5 REVERIE
 Build Date : 11/04/2026
 - Synced with latest AxionAOSP sources (11/04/2026)

--- a/OTA/CHANGELOG/frankel.txt
+++ b/OTA/CHANGELOG/frankel.txt
@@ -1,3 +1,10 @@
+AxionOS v2.6 QUASIS
+Build Date : 23/05/2026
+- Synced with latest AxionAOSP sources (23/05/2026)
+- Added Google Face Unlock for better device security ang use of hardware
+- Vendor Firmware stripped so users with may firmware dont brick!!
+- Vanilla Builds are now here!!!
+
 AxionOS v2.5 REVERIE
 Build Date : 11/04/2026
 - Synced with latest AxionAOSP sources (11/04/2026)

--- a/OTA/CHANGELOG/mustang.txt
+++ b/OTA/CHANGELOG/mustang.txt
@@ -1,3 +1,10 @@
+AxionOS v2.6 QUASIS
+Build Date : 23/05/2026
+- Synced with latest AxionAOSP sources (23/05/2026)
+- Added Google Face Unlock for better device security ang use of hardware
+- Vendor Firmware stripped so users with may firmware dont brick!!
+- Vanilla Builds are now here!!!
+
 AxionOS v2.5 REVERIE
 Build Date : 11/04/2026
 - Synced with latest AxionAOSP sources (11/04/2026)

--- a/OTA/GMS/blazer.json
+++ b/OTA/GMS/blazer.json
@@ -1,13 +1,13 @@
 {
     "response": [
         {
-            "datetime": 1775933754,
-            "filename": "axion-2.5-REVERIE-20260411-OFFICIAL-GMS-blazer.zip",
-            "id": "b3f0896d00a8ddf53f4f8e08d9e65375",
+            "datetime": 1779560674,
+            "filename": "axion-2.6-QUASIS-20260523-OFFICIAL-GMS-blazer.zip",
+            "id": "f84eb6d72f5d4a63991501ea3b245e86",
             "romtype": "OFFICIAL",
-            "size": 3201196659,
-            "url": "https://sourceforge.net/projects/axionaosp-for-pixel-10-series/files/blazer/axion-2.5-REVERIE-20260411-OFFICIAL-GMS-blazer.zip/download",
-            "version": "2.5"
+            "size": 2183952495,
+            "url": "https://cdn.axionos.org/blazer/axion-2.6-QUASIS-20260523-OFFICIAL-GMS-blazer.zip",
+            "version": "2.6"
         }
     ]
 }

--- a/OTA/GMS/frankel.json
+++ b/OTA/GMS/frankel.json
@@ -1,13 +1,13 @@
 {
     "response": [
         {
-            "datetime": 1775934542,
-            "filename": "axion-2.5-REVERIE-20260411-OFFICIAL-GMS-frankel.zip",
-            "id": "f9f915152613457e78581ad755b03ab5",
+            "datetime": 1779561527,
+            "filename": "axion-2.6-QUASIS-20260523-OFFICIAL-GMS-frankel.zip",
+            "id": "145dfc150cc80bb9dd235259c95f920b",
             "romtype": "OFFICIAL",
-            "size": 3198059830,
-            "url": "https://sourceforge.net/projects/axionaosp-for-pixel-10-series/files/frankel/axion-2.5-REVERIE-20260411-OFFICIAL-GMS-frankel.zip/download",
-            "version": "2.5"
+            "size": 2181015063,
+            "url": "https://cdn.axionos.org/frankel/axion-2.6-QUASIS-20260523-OFFICIAL-GMS-frankel.zip",
+            "version": "2.6"
         }
     ]
 }

--- a/OTA/GMS/mustang.json
+++ b/OTA/GMS/mustang.json
@@ -1,13 +1,13 @@
 {
     "response": [
         {
-            "datetime": 1775931541,
-            "filename": "axion-2.5-REVERIE-20260411-OFFICIAL-GMS-mustang.zip",
-            "id": "44a00bf10c1980e4a6335e85f4ee9560",
+            "datetime": 1779559314,
+            "filename": "axion-2.6-QUASIS-20260523-OFFICIAL-GMS-mustang.zip",
+            "id": "1b567d825cb7c71c7ed6956b975fd7b6",
             "romtype": "OFFICIAL",
-            "size": 3205453414,
-            "url": "https://sourceforge.net/projects/axionaosp-for-pixel-10-series/files/mustang/axion-2.5-REVERIE-20260411-OFFICIAL-GMS-mustang.zip/download",
-            "version": "2.5"
+            "size": 2188634937,
+            "url": "https://cdn.axionos.org/mustang/axion-2.6-QUASIS-20260523-OFFICIAL-GMS-mustang.zip",
+            "version": "2.6"
         }
     ]
 }

--- a/OTA/VANILLA/blazer.json
+++ b/OTA/VANILLA/blazer.json
@@ -1,0 +1,13 @@
+{
+    "response": [
+        {
+            "datetime": 1779563796,
+            "filename": "axion-2.6-QUASIS-20260523-OFFICIAL-VANILLA-blazer.zip",
+            "id": "8a13a78a2136b33bcc2d59c552303da7",
+            "romtype": "OFFICIAL",
+            "size": 1776113033,
+            "url": "https://cdn.axionos.org/blazer/axion-2.6-QUASIS-20260523-OFFICIAL-VANILLA-blazer.zip",
+            "version": "2.6"
+        }
+    ]
+}

--- a/OTA/VANILLA/frankel.json
+++ b/OTA/VANILLA/frankel.json
@@ -1,0 +1,13 @@
+{
+    "response": [
+        {
+            "datetime": 1779564534,
+            "filename": "axion-2.6-QUASIS-20260523-OFFICIAL-VANILLA-frankel.zip",
+            "id": "e2e9605856c44d3a1bcffada89fc82de",
+            "romtype": "OFFICIAL",
+            "size": 1773042801,
+            "url": "https://cdn.axionos.org/frankel/axion-2.6-QUASIS-20260523-OFFICIAL-VANILLA-frankel.zip",
+            "version": "2.6"
+        }
+    ]
+}

--- a/OTA/VANILLA/mustang.json
+++ b/OTA/VANILLA/mustang.json
@@ -1,0 +1,13 @@
+{
+    "response": [
+        {
+            "datetime": 1779563017,
+            "filename": "axion-2.6-QUASIS-20260523-OFFICIAL-VANILLA-mustang.zip",
+            "id": "a01e00bf1fe2adbec8954731c27d144b",
+            "romtype": "OFFICIAL",
+            "size": 1780606370,
+            "url": "https://cdn.axionos.org/mustang/axion-2.6-QUASIS-20260523-OFFICIAL-VANILLA-mustang.zip",
+            "version": "2.6"
+        }
+    ]
+}

--- a/Wiki/blazer.md
+++ b/Wiki/blazer.md
@@ -38,7 +38,7 @@ Only needs to be done once.
 
 ## Flash the AxionOS recovery
 
-1. Download `vendor_boot.img` for **blazer** from the [AxionOS website](https://cdn.axionos.org).
+1. Download `vendor_boot.img` for **blazer** from the [AxionOS Maintainers GDrive](https://drive.google.com/drive/folders/1O25lGqydo_n3MZJKa24GusCvT68lUpHt).
 2. Reboot to the bootloader:
    ```
    adb reboot bootloader

--- a/Wiki/frankel.md
+++ b/Wiki/frankel.md
@@ -38,7 +38,7 @@ Only needs to be done once.
 
 ## Flash the AxionOS recovery
 
-1. Download `vendor_boot.img` for **frankel** from the [AxionOS website](https://cdn.axionos.org).
+1. Download `vendor_boot.img` for **frankel** from the [AxionOS Maintainers GDrive](https://drive.google.com/drive/folders/1O25lGqydo_n3MZJKa24GusCvT68lUpHt).
 2. Reboot to the bootloader:
    ```
    adb reboot bootloader

--- a/Wiki/mustang.md
+++ b/Wiki/mustang.md
@@ -38,7 +38,7 @@ Only needs to be done once.
 
 ## Flash the AxionOS recovery
 
-1. Download `vendor_boot.img` for **mustang** from the [AxionOS website](https://cdn.axionos.org).
+1. Download `vendor_boot.img` for **mustang** from the [AxionOS Maintainers GDrive](https://drive.google.com/drive/folders/1O25lGqydo_n3MZJKa24GusCvT68lUpHt).
 2. Reboot to the bootloader:
    ```
    adb reboot bootloader


### PR DESCRIPTION
Bumps AxionOS to version 2.6, codenamed "QUASIS", for `frankel`, `blazer`, and `mustang` devices. ( Pixel 10 Series )

This release integrates Google Face Unlock, features stripped vendor firmware for improved compatibility, and introduces official Vanilla builds.

Updates OTA metadata for both GMS and the new Vanilla variants, transitioning download URLs from SourceForge to the AxionOS CDN. Refreshes recovery flashing documentation to reflect the new GDrive source for `vendor_boot.img` files.